### PR TITLE
HGI-9989: implement empty_string_to_null config flag

### DIFF
--- a/target_parquet/sinks.py
+++ b/target_parquet/sinks.py
@@ -81,8 +81,13 @@ def build_pyarrow_field(key: str, value: dict):
     )
 
 
-def parse_record_value(record_value, property: dict, logger: logging.Logger):
-    if record_value in [None, ""]:
+def parse_record_value(
+    record_value,
+    property: dict,
+    logger: logging.Logger,
+    empty_string_to_null: bool = True,
+):
+    if record_value is None:
         return None
 
     if "anyOf" in property:
@@ -93,6 +98,9 @@ def parse_record_value(record_value, property: dict, logger: logging.Logger):
         type_id = types[0] if isinstance(types, list) else types
     else:
         type_id = "string"
+
+    if record_value == "" and (empty_string_to_null or type_id != "string"):
+        return None
 
     if type_id == "number":
         return float(record_value)
@@ -203,9 +211,10 @@ class ParquetSink(BatchSink):
 
     def process_record(self, record: dict, context: dict) -> None:
         """Process the record."""
+        empty_string_to_null = self.config.get("empty_string_to_null", True)
 
         for (key, property) in self.schema["properties"].items():
-            record[key] = parse_record_value(record.get(key), property, self.logger)
+            record[key] = parse_record_value(record.get(key), property, self.logger, empty_string_to_null)
 
         context["records"].append(record)
 

--- a/target_parquet/sinks.py
+++ b/target_parquet/sinks.py
@@ -109,6 +109,8 @@ def parse_record_value(
         return int(record_value)
 
     if type_id == "string" and property.get("format") == "date-time":
+        if record_value == "":
+            return None
         if isinstance(record_value, datetime.datetime):
             return record_value
         try:

--- a/target_parquet/target.py
+++ b/target_parquet/target.py
@@ -25,10 +25,8 @@ class TargetParquet(Target):
         th.Property(
             "empty_string_to_null",
             th.BooleanType,
-            description=(
-                "When true, empty string values ('') are written as null. "
-                "Defaults to true."
-            ),
+            default=True,
+            description="When true, empty string values ('') are written as null.",
         ),
     ).to_dict()
     default_sink_class = ParquetSink

--- a/target_parquet/target.py
+++ b/target_parquet/target.py
@@ -22,6 +22,14 @@ class TargetParquet(Target):
             th.StringType,
             description="The scheme with which output files will be named",
         ),
+        th.Property(
+            "empty_string_to_null",
+            th.BooleanType,
+            description=(
+                "When true, empty string values ('') are written as null. "
+                "Defaults to true."
+            ),
+        ),
     ).to_dict()
     default_sink_class = ParquetSink
 

--- a/target_parquet/tests/test_integration_types.py
+++ b/target_parquet/tests/test_integration_types.py
@@ -253,6 +253,56 @@ class TestFixedHeadersConfig:
         assert table.column("name")[0].as_py() == "Alice"
 
 
+class TestEmptyStringToNullConfig:
+    """empty_string_to_null config flag controls empty string handling."""
+
+    _PROPS = {
+        "id": {"type": ["string", "null"]},
+        "name": {"type": ["string", "null"]},
+        "count": {"type": ["integer", "null"]},
+    }
+
+    def test_empty_string_becomes_null_when_flag_is_true(self, tmp_path):
+        """With empty_string_to_null=True (default), '' is written as null for all types."""
+        messages = [
+            schema_message("users", self._PROPS, ["id"]),
+            record_message("users", {"id": "1", "name": "", "count": None}),
+        ]
+        run_target(messages, config={"empty_string_to_null": True})
+        table = read_parquet_for_stream(tmp_path, "users")
+        assert table.column("name")[0].as_py() is None
+
+    def test_empty_string_preserved_when_flag_is_false(self, tmp_path):
+        """With empty_string_to_null=False, '' is preserved as '' for string columns."""
+        messages = [
+            schema_message("users", self._PROPS, ["id"]),
+            record_message("users", {"id": "1", "name": "", "count": None}),
+        ]
+        run_target(messages, config={"empty_string_to_null": False})
+        table = read_parquet_for_stream(tmp_path, "users")
+        assert table.column("name")[0].as_py() == ""
+
+    def test_empty_string_on_non_string_still_null_when_flag_is_false(self, tmp_path):
+        """With empty_string_to_null=False, '' on an integer column is still null."""
+        messages = [
+            schema_message("users", self._PROPS, ["id"]),
+            record_message("users", {"id": "1", "name": "Alice", "count": ""}),
+        ]
+        run_target(messages, config={"empty_string_to_null": False})
+        table = read_parquet_for_stream(tmp_path, "users")
+        assert table.column("count")[0].as_py() is None
+
+    def test_empty_string_to_null_defaults_to_true(self, tmp_path):
+        """Without the flag, empty strings are converted to null (backward-compatible default)."""
+        messages = [
+            schema_message("users", self._PROPS, ["id"]),
+            record_message("users", {"id": "1", "name": "", "count": None}),
+        ]
+        run_target(messages)
+        table = read_parquet_for_stream(tmp_path, "users")
+        assert table.column("name")[0].as_py() is None
+
+
 class TestStrictValidationConfig:
     """_validate_and_parse strict_validation flag controls exception propagation."""
 


### PR DESCRIPTION
- Added a new configuration option `empty_string_to_null` to control whether empty strings are converted to null values.
- Updated the `parse_record_value` function to respect this configuration.
- Added integration tests to verify the behavior of the new configuration option.